### PR TITLE
Add a call to request_input to example app

### DIFF
--- a/templates/new/lib/scenes/home.ex.eex
+++ b/templates/new/lib/scenes/home.ex.eex
@@ -31,6 +31,7 @@ defmodule <%= @mod %>.Scene.Home do
     driver_ver = Application.spec(:scenic_driver_local, :vsn) |> to_string()
 
     info = "scenic: v#{scenic_ver}\nscenic_driver_local: v#{driver_ver}"
+    request_input(scene, [:key, :cursor_pos, :codepoint])
 
     graph =
       Graph.build(font: :roboto, font_size: @text_size)


### PR DESCRIPTION
Adds a call to request_input so that input events will be logged in generated scene for the example app.